### PR TITLE
Fix hanging indents for admonition (eg NOTE) blocks

### DIFF
--- a/tree-sitter-asciidoc/test/corpus/admonition.txt
+++ b/tree-sitter-asciidoc/test/corpus/admonition.txt
@@ -9,6 +9,9 @@ IMPORTANT: aaaa
 CAUTION: aaaa
 WARNING: aaaa
 
+NOTE: Line 1
+    Line 2
+
 -----
 
 (document
@@ -36,4 +39,10 @@ WARNING: aaaa
     (section_block
       (admonition
         (admonition_warning)
+        (line)))))
+  (block_element
+    (section_block
+      (admonition
+        (admonition_note)
+        (line)
         (line)))))


### PR DESCRIPTION
Hi there, not sure if bug reports / suggestions are welcome, but I noticed some strange highlighting for "hanging indented" blocks.  I noticed it with `NOTE:` admonitions, but it also happens for `<1> callouts`.  example:

```asciidoc
NOTE: Line 1
  Line 2
```

highlights as:

<img width="120" alt="image" src="https://github.com/user-attachments/assets/10da4c6d-ad6a-41c4-884f-092f67dfb53f" />

looking at `InspectTree`, i think it's recognising the second line as being a separate block?

```
  (block_element ; [1, 0] - [2, 0]
    (section_block ; [1, 0] - [2, 0]
      (admonition ; [1, 0] - [2, 0]
        (admonition_note) ; [1, 0] - [1, 4]
        (line)))) ; [1, 6] - [2, 0]
  (block_element ; [2, 0] - [3, 0]
    (section_block ; [2, 0] - [3, 0]
      (ident_block ; [2, 0] - [3, 0]
        (ident_block_line ; [2, 0] - [3, 0]
          (ident_marker)))))) ; [2, 0] - [2, 2]
```

In an attempt to be hepful, I've tried to add an example in the tests corpus, with my non-expert best guess as to what the tree _should_ be?