### PR TITLE
feat(scanner): include the admonition label in its token

### DIFF
--- a/tree-sitter-asciidoc/src/scanner.c
+++ b/tree-sitter-asciidoc/src/scanner.c
@@ -88,9 +88,13 @@ bool tree_sitter_asciidoc_external_scanner_scan(void *payload, TSLexer *lexer, c
                     break;
                 }
 
+                // mark_end caps the token at the keyword word; the colon and
+                // space are only lookahead.  Advance them with skip=false: a
+                // skip=true advance after mark_end would collapse the token to
+                // a zero-width marker (the label would fall outside the tree).
                 lexer->mark_end(lexer);
                 if(lexer->lookahead == ':') {
-                    lexer->advance(lexer, true);
+                    lexer->advance(lexer, false);
                     if(lexer->lookahead == ' ') {
                         return true;
                     }


### PR DESCRIPTION
The admonition keyword tokens (`admonition_note`, etc.) are currently emitted **zero-width**: the scanner advances over the label word, but then advances past the colon with `skip=true` *after* `mark_end`, which collapses the token to a zero-width marker. The label word ends up outside the parse tree, so it cannot be queried or highlighted.

Before, for `NOTE: text`:
```
(admonition
  (admonition_note [0, 4] - [0, 4])   ; empty, at the colon
  (line [0, 6] - [1, 0]))
```

After:
```
(admonition
  (admonition_note [0, 0] - [0, 4])   ; spans "NOTE"
  (line [0, 6] - [1, 0]))
```

The fix advances the colon with `skip=false` (it stays lookahead, since `mark_end` already capped the token at the keyword word) - the same pattern the `term` scanner uses for its trailing `::`/`;;` delimiter. No grammar change, node structure is unchanged, and all corpus tests still pass.

Spec: the paragraph admonition `LABEL: text` (LABEL = NOTE/TIP/IMPORTANT/CAUTION/WARNING) is documented at https://docs.asciidoctor.org/asciidoc/latest/blocks/admonitions/. Downstream, `asciidoc-mode` wants to fontify the label off the grammar instead of a regex fallback.