### PR TITLE
feat(scanner): parse Markdown-style ATX headings

### DIFF
--- a/tree-sitter-asciidoc/src/scanner.c
+++ b/tree-sitter-asciidoc/src/scanner.c
@@ -180,6 +180,21 @@ bool tree_sitter_asciidoc_external_scanner_scan(void *payload, TSLexer *lexer, c
                     }
                     break;
                 }
+                case '#': {
+                    // Markdown-style ATX heading (compat syntax): a run of `#`
+                    // maps to the same section levels as `=` (`#` -> level 0,
+                    // `######` -> level 5), requiring a space before the title.
+                    consume('#', lexer, false, NULL, USIZE_MAX);
+                    lexer->mark_end(lexer);
+                    if(!scanner_is_matching_raw_block(s)) {
+                        usize level = TOKEN_TITLE_H0_MARKER - 1 + lexer->get_column(lexer);
+                        if(level <= TOKEN_TITLE_H5_MARKER && is_white_space(lexer->lookahead)) {
+                            lexer->result_symbol = level;
+                            return true;
+                        }
+                    }
+                    break;
+                }
                 case '*': {
                     usize counter = 0;
                     consume('*', lexer, false, &counter, USIZE_MAX);

--- a/tree-sitter-asciidoc/test/corpus/atx_title.txt
+++ b/tree-sitter-asciidoc/test/corpus/atx_title.txt
@@ -1,0 +1,105 @@
+==================
+atx document title
+==================
+
+# Doc Title
+
+--------
+
+(document
+  (block_element
+    (document_title
+      (title_h0_marker)
+      (line))))
+
+==================
+atx section titles
+==================
+
+## Level 1
+
+### Level 2
+
+#### Level 3
+
+##### Level 4
+
+###### Level 5
+
+--------
+
+(document
+  (block_element
+    (section_block
+      (title1
+        (title_h1_marker)
+        (line))))
+  (block_element
+    (section_block
+      (title2
+        (title_h2_marker)
+        (line))))
+  (block_element
+    (section_block
+      (title3
+        (title_h3_marker)
+        (line))))
+  (block_element
+    (section_block
+      (title4
+        (title_h4_marker)
+        (line))))
+  (block_element
+    (section_block
+      (title5
+        (title_h5_marker)
+        (line)))))
+
+=============================
+atx heading followed by text
+=============================
+
+## Section Title
+
+Some text.
+
+--------
+
+(document
+  (block_element
+    (section_block
+      (title1
+        (title_h1_marker)
+        (line))))
+  (block_element
+    (section_block
+      (paragraph
+        (line)))))
+
+==================================
+hashes without a space stay text
+==================================
+
+#NoSpace#
+
+--------
+
+(document
+  (block_element
+    (section_block
+      (paragraph
+        (line)))))
+
+==================================
+too many hashes are not a heading
+==================================
+
+####### Seven
+
+--------
+
+(document
+  (block_element
+    (section_block
+      (paragraph
+        (line)))))


### PR DESCRIPTION
Asciidoctor accepts Markdown ATX headings as compatibility syntax, mapping `#` to a level-0 title, `##` to level 1, and so on. The block scanner only recognized the `=` form, so a `#`-prefixed line fell through to a paragraph.

This adds a `#` case in the scanner mirroring the existing `=` title logic: count the run of `#` at column 0, map it to the same `title_h0`..`title_h5` markers, and require a trailing space. It reuses the existing title rules, so:

- `#NoSpace#` and a bare `#` stay paragraphs (no trailing space),
- more than six `#` is not a heading,
- `#` inside a raw block (listing/literal) stays literal.

Corpus tests cover the level mapping and these negative cases. No grammar regeneration needed since only the hand-written scanner changed.