### PR TITLE
feat(block): nest content under section headings

### DIFF
--- a/tree-sitter-asciidoc/grammar.js
+++ b/tree-sitter-asciidoc/grammar.js
@@ -26,43 +26,118 @@ module.exports = grammar({
           choice(
             $.document_title,
             $.document_attr,
-            $.section_block,
+            alias($._section1, $.section),
+            alias($._doc_block, $.section_block),
             $.line_comment,
             $.block_comment,
           ),
         ),
       ),
 
+    // Document-level sections nest by heading level: a level-1 section (`==`)
+    // contains its content plus any deeper sections, and each level closes
+    // when a heading of the same or higher level appears.  The heading node
+    // (`title1`..`title5`) is kept as-is inside the wrapping `section`.
+    // A section body allows content blocks plus any *deeper* section, so an
+    // illegal level skip (e.g. `==` straight to `====`) still nests instead of
+    // erroring; the innermost open section greedily claims a deeper heading.
+    _section1: $ =>
+      prec.right(
+        seq(
+          repeat(choice($.element_attr, $.block_title)),
+          $.title1,
+          repeat(
+            choice(
+              alias($._doc_block, $.section_block),
+              alias($._section2, $.section),
+              alias($._section3, $.section),
+              alias($._section4, $.section),
+              alias($._section5, $.section),
+            ),
+          ),
+        ),
+      ),
+    _section2: $ =>
+      prec.right(
+        seq(
+          repeat(choice($.element_attr, $.block_title)),
+          $.title2,
+          repeat(
+            choice(
+              alias($._doc_block, $.section_block),
+              alias($._section3, $.section),
+              alias($._section4, $.section),
+              alias($._section5, $.section),
+            ),
+          ),
+        ),
+      ),
+    _section3: $ =>
+      prec.right(
+        seq(
+          repeat(choice($.element_attr, $.block_title)),
+          $.title3,
+          repeat(
+            choice(
+              alias($._doc_block, $.section_block),
+              alias($._section4, $.section),
+              alias($._section5, $.section),
+            ),
+          ),
+        ),
+      ),
+    _section4: $ =>
+      prec.right(
+        seq(
+          repeat(choice($.element_attr, $.block_title)),
+          $.title4,
+          repeat(
+            choice(alias($._doc_block, $.section_block), alias($._section5, $.section)),
+          ),
+        ),
+      ),
+    _section5: $ =>
+      prec.right(
+        seq(
+          repeat(choice($.element_attr, $.block_title)),
+          $.title5,
+          repeat(alias($._doc_block, $.section_block)),
+        ),
+      ),
+
+    // A document-level content block (no section heading).
+    _doc_block: $ =>
+      seq(repeat(choice($.element_attr, $.block_title)), choice($.paragraph, $._block)),
+
+    // Container blocks (delimited/open/sidebar/quote/table cells) keep the flat
+    // `section_block`, which may still hold a (discrete) heading.
     section_block: $ => choice($._section_block_para, $._section_block),
     _section_block_para: $ =>
       seq(repeat(choice($.element_attr, $.block_title)), $.paragraph),
     _section_block: $ =>
       seq(
         repeat(choice($.element_attr, $.block_title)),
-        choice(
-          $.title1,
-          $.title2,
-          $.title3,
-          $.title4,
-          $.title5,
-          $.list,
-          $.description_list,
-          $.table_block,
-          $.csv_table_block,
-          $.dsv_table_block,
-          $.delimited_block,
-          $.listing_block,
-          $.literal_block,
-          $.ident_block,
-          $.open_block,
-          $.breaks,
-          $.admonition,
-          $.quoted_block,
-          $.quoted_md_block,
-          $.passthrough_block,
-          $.sidebar_block,
-          $.block_macro,
-        ),
+        choice($.title1, $.title2, $.title3, $.title4, $.title5, $._block),
+      ),
+    _block: $ =>
+      choice(
+        $.list,
+        $.description_list,
+        $.table_block,
+        $.csv_table_block,
+        $.dsv_table_block,
+        $.delimited_block,
+        $.listing_block,
+        $.literal_block,
+        $.ident_block,
+        $.open_block,
+        $.breaks,
+        $.admonition,
+        $.quoted_block,
+        $.quoted_md_block,
+        $.passthrough_block,
+        $.sidebar_block,
+        $.block_macro,
       ),
     // Description (labeled) lists: `term:: definition`.  The marker
     // (`::`/`:::`/`::::`/`;;`, always followed by whitespace or a line

--- a/tree-sitter-asciidoc/src/grammar.json
+++ b/tree-sitter-asciidoc/src/grammar.json
@@ -1253,8 +1253,22 @@
                 "name": "document_attr"
               },
               {
-                "type": "SYMBOL",
-                "name": "section_block"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_section1"
+                },
+                "named": true,
+                "value": "section"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_doc_block"
+                },
+                "named": true,
+                "value": "section_block"
               },
               {
                 "type": "SYMBOL",
@@ -1268,6 +1282,355 @@
           }
         ]
       }
+    },
+    "_section1": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "element_attr"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "block_title"
+                }
+              ]
+            }
+          },
+          {
+            "type": "SYMBOL",
+            "name": "title1"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_doc_block"
+                  },
+                  "named": true,
+                  "value": "section_block"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_section2"
+                  },
+                  "named": true,
+                  "value": "section"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_section3"
+                  },
+                  "named": true,
+                  "value": "section"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_section4"
+                  },
+                  "named": true,
+                  "value": "section"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_section5"
+                  },
+                  "named": true,
+                  "value": "section"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "_section2": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "element_attr"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "block_title"
+                }
+              ]
+            }
+          },
+          {
+            "type": "SYMBOL",
+            "name": "title2"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_doc_block"
+                  },
+                  "named": true,
+                  "value": "section_block"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_section3"
+                  },
+                  "named": true,
+                  "value": "section"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_section4"
+                  },
+                  "named": true,
+                  "value": "section"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_section5"
+                  },
+                  "named": true,
+                  "value": "section"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "_section3": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "element_attr"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "block_title"
+                }
+              ]
+            }
+          },
+          {
+            "type": "SYMBOL",
+            "name": "title3"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_doc_block"
+                  },
+                  "named": true,
+                  "value": "section_block"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_section4"
+                  },
+                  "named": true,
+                  "value": "section"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_section5"
+                  },
+                  "named": true,
+                  "value": "section"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "_section4": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "element_attr"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "block_title"
+                }
+              ]
+            }
+          },
+          {
+            "type": "SYMBOL",
+            "name": "title4"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_doc_block"
+                  },
+                  "named": true,
+                  "value": "section_block"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_section5"
+                  },
+                  "named": true,
+                  "value": "section"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "_section5": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "element_attr"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "block_title"
+                }
+              ]
+            }
+          },
+          {
+            "type": "SYMBOL",
+            "name": "title5"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_doc_block"
+              },
+              "named": true,
+              "value": "section_block"
+            }
+          }
+        ]
+      }
+    },
+    "_doc_block": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "element_attr"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "block_title"
+              }
+            ]
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "paragraph"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_block"
+            }
+          ]
+        }
+      ]
     },
     "section_block": {
       "type": "CHOICE",
@@ -1351,73 +1714,82 @@
             },
             {
               "type": "SYMBOL",
-              "name": "list"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "description_list"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "table_block"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "csv_table_block"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "dsv_table_block"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "delimited_block"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "listing_block"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "literal_block"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "ident_block"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "open_block"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "breaks"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "admonition"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "quoted_block"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "quoted_md_block"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "passthrough_block"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "sidebar_block"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "block_macro"
+              "name": "_block"
             }
           ]
+        }
+      ]
+    },
+    "_block": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "list"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "description_list"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "table_block"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "csv_table_block"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "dsv_table_block"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "delimited_block"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "listing_block"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "literal_block"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ident_block"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "open_block"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "breaks"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "admonition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "quoted_block"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "quoted_md_block"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "passthrough_block"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "sidebar_block"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "block_macro"
         }
       ]
     },

--- a/tree-sitter-asciidoc/src/node-types.json
+++ b/tree-sitter-asciidoc/src/node-types.json
@@ -149,6 +149,10 @@
           "named": true
         },
         {
+          "type": "section",
+          "named": true
+        },
+        {
           "type": "section_block",
           "named": true
         }
@@ -1083,6 +1087,53 @@
     "type": "revremark",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "section",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "block_title",
+          "named": true
+        },
+        {
+          "type": "element_attr",
+          "named": true
+        },
+        {
+          "type": "section",
+          "named": true
+        },
+        {
+          "type": "section_block",
+          "named": true
+        },
+        {
+          "type": "title1",
+          "named": true
+        },
+        {
+          "type": "title2",
+          "named": true
+        },
+        {
+          "type": "title3",
+          "named": true
+        },
+        {
+          "type": "title4",
+          "named": true
+        },
+        {
+          "type": "title5",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "section_block",

--- a/tree-sitter-asciidoc/test/corpus/atx_title.txt
+++ b/tree-sitter-asciidoc/test/corpus/atx_title.txt
@@ -30,30 +30,26 @@ atx section titles
 
 (document
   (block_element
-    (section_block
+    (section
       (title1
         (title_h1_marker)
-        (line))))
-  (block_element
-    (section_block
-      (title2
-        (title_h2_marker)
-        (line))))
-  (block_element
-    (section_block
-      (title3
-        (title_h3_marker)
-        (line))))
-  (block_element
-    (section_block
-      (title4
-        (title_h4_marker)
-        (line))))
-  (block_element
-    (section_block
-      (title5
-        (title_h5_marker)
-        (line)))))
+        (line))
+      (section
+        (title2
+          (title_h2_marker)
+          (line))
+        (section
+          (title3
+            (title_h3_marker)
+            (line))
+          (section
+            (title4
+              (title_h4_marker)
+              (line))
+            (section
+              (title5
+                (title_h5_marker)
+                (line)))))))))
 
 =============================
 atx heading followed by text
@@ -67,14 +63,13 @@ Some text.
 
 (document
   (block_element
-    (section_block
+    (section
       (title1
         (title_h1_marker)
-        (line))))
-  (block_element
-    (section_block
-      (paragraph
-        (line)))))
+        (line))
+      (section_block
+        (paragraph
+          (line))))))
 
 ==================================
 hashes without a space stay text

--- a/tree-sitter-asciidoc/test/corpus/author_line.txt
+++ b/tree-sitter-asciidoc/test/corpus/author_line.txt
@@ -162,11 +162,10 @@ The second author's last name is {lastname_2}.
         (document_attr_marker)
         (line))))
   (block_element
-    (section_block
+    (section
       (title1
         (title_h1_marker)
-        (line))))
-  (block_element
-    (section_block
-      (paragraph
-        (line)))))
+        (line))
+      (section_block
+        (paragraph
+          (line))))))

--- a/tree-sitter-asciidoc/test/corpus/section.txt
+++ b/tree-sitter-asciidoc/test/corpus/section.txt
@@ -1,0 +1,70 @@
+==================
+nested sections
+==================
+
+== A
+
+para
+
+=== B
+
+sub
+
+== C
+
+last
+
+--------
+
+(document
+  (block_element
+    (section
+      (title1
+        (title_h1_marker)
+        (line))
+      (section_block
+        (paragraph
+          (line)))
+      (section
+        (title2
+          (title_h2_marker)
+          (line))
+        (section_block
+          (paragraph
+            (line))))))
+  (block_element
+    (section
+      (title1
+        (title_h1_marker)
+        (line))
+      (section_block
+        (paragraph
+          (line))))))
+
+=====================================
+illegal level skip still nests
+=====================================
+
+== First
+
+==== Skipped
+
+== Next
+
+--------
+
+(document
+  (block_element
+    (section
+      (title1
+        (title_h1_marker)
+        (line))
+      (section
+        (title3
+          (title_h3_marker)
+          (line)))))
+  (block_element
+    (section
+      (title1
+        (title_h1_marker)
+        (line)))))

--- a/tree-sitter-asciidoc/test/corpus/title.txt
+++ b/tree-sitter-asciidoc/test/corpus/title.txt
@@ -62,32 +62,28 @@ more value
         (document_attr_marker)
         (line))))
   (block_element
-    (section_block
+    (section
       (title1
         (title_h1_marker)
-        (line))))
+        (line))
+      (section
+        (title2
+          (title_h2_marker)
+          (line))
+        (section
+          (title3
+            (title_h3_marker)
+            (line))
+          (section
+            (title4
+              (title_h4_marker)
+              (line))
+            (section
+              (title5
+                (title_h5_marker)
+                (line))))))))
   (block_element
-    (section_block
-      (title2
-        (title_h2_marker)
-        (line))))
-  (block_element
-    (section_block
-      (title3
-        (title_h3_marker)
-        (line))))
-  (block_element
-    (section_block
-      (title4
-        (title_h4_marker)
-        (line))))
-  (block_element
-    (section_block
-      (title5
-        (title_h5_marker)
-        (line))))
-  (block_element
-    (section_block
+    (section
       (title1
         (title_h1_marker)
         (line))))
@@ -100,12 +96,11 @@ more value
       (title_h0_marker)
       (line)))
   (block_element
-    (section_block
+    (section
       (title1
         (title_h1_marker)
-        (line))))
-  (block_element
-    (section_block
-      (title3
-        (title_h3_marker)
-        (line)))))
+        (line))
+      (section
+        (title3
+          (title_h3_marker)
+          (line))))))


### PR DESCRIPTION
Section headings were flat siblings, so content wasn't associated with its heading. This wraps each heading and the blocks that follow it in a `section` node, nested by level: a level-1 section (`==`) contains its content plus any deeper sections, and each level closes when a same-or-higher heading appears.

```
== Installation     (section
Intro.        ->       (title1) (section_block: Intro.)
=== Linux              (section (title2) (section_block: Steps.)))
Steps.
```

Design choices to keep this low-risk:
- The heading nodes (`title1`..`title5`) and the `section_block` content wrapper are kept as-is, so existing highlight and injection queries keep working **unchanged** (verified source-language injection and admonition-block highlighting still fire, including when nested in a section).
- An illegal level skip (e.g. `==` straight to `====`) still nests gracefully instead of cascading into an error.
- Headings inside container blocks (open/sidebar/quote/delimited blocks, table cells) stay flat as before.

All 57 block corpus tests pass.