### PR TITLE
docs: expand README and add architecture/design docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,123 @@
 ![Crates.io Version](https://img.shields.io/crates/v/tree-sitter-asciidoc?label=tree-sitter-asciidoc(crates.io))
 ![Crates.io Version](https://img.shields.io/crates/v/tree-sitter-asciidoc_inline?label=tree-sitter-asciidoc_inline(crates.io))
 
-[asciidoc](https://docs.asciidoctor.org/asciidoc/latest/) grammar for tree-sitter.
+A [tree-sitter](https://tree-sitter.github.io/tree-sitter/) grammar for
+[AsciiDoc](https://docs.asciidoctor.org/asciidoc/latest/), the markup language.
+
+It targets the AsciiDoc language as documented by Asciidoctor (the de-facto
+reference while the [Eclipse AsciiDoc Language
+specification](https://gitlab.eclipse.org/eclipse/asciidoc-lang/asciidoc-lang)
+is still in progress).
+
+## Two grammars
+
+AsciiDoc is parsed by two cooperating grammars, a common pattern for markup
+languages in tree-sitter (Markdown does the same):
+
+| Package | Scope | Responsibility |
+| --- | --- | --- |
+| `tree-sitter-asciidoc` | block | Document structure: sections, lists, tables, delimited blocks, admonitions, block macros, comments. |
+| `tree-sitter-asciidoc_inline` | inline | Span-level markup inside a line: bold/italic/monospace, macros, attribute references, autolinks, replacements. |
+
+The block grammar parses a document into blocks, then **injects** the inline
+grammar into the text-bearing parts (paragraph lines, table cells, macro
+targets) via `queries/injections.scm`. Splitting the two keeps each grammar and
+its external scanner tractable. See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+for how the pieces fit together.
+
+## What it parses
+
+- **Document header**: title, author line, revision line, attribute entries (with `\` line continuation)
+- **Sections**: `==`..`======` headings, nested into a `section` tree, plus Markdown-style `#` ATX headings
+- **Blocks**: listing (`----`), literal (`....`), example (`====`), sidebar (`****`), quote (`____`), open (`--`), passthrough (`++++`), Markdown fenced code (` ``` `)
+- **Lists**: unordered, ordered, checklists, callouts, description lists
+- **Tables**: `|===`, CSV (`,===`), DSV (`:===`), nested cells
+- **Block attribute lists** parsed into structure: `[source#id.role%opt,ruby,cols="1,2"]` becomes a style, id, roles, options, positional and named attributes
+- **Block macros**: `image::`, `include::`, `video::`, `toc::`, conditionals, and more
+- **Inline**: constrained and unconstrained formatting, super/subscript, typographic quotes, role spans, a large macro set (link, image, xref, footnote, kbd, btn, menu, stem, pass, indexterm, diagrams), structured macro attributes, attribute references including counters, autolinks, replacements, escapes
+- **Comments**, thematic and page breaks
+
+The known gaps are tracked in [docs/LIMITATIONS.md](docs/LIMITATIONS.md), and the
+things we want to tackle next live in [docs/ROADMAP.md](docs/ROADMAP.md).
+
+## Installation
+
+The grammars are published for several language bindings. Pick the one for your
+host language.
+
+JavaScript / Node:
+
+```sh
+npm install tree-sitter-asciidoc tree-sitter-asciidoc_inline
+```
+
+Rust:
+
+```toml
+[dependencies]
+tree-sitter-asciidoc = "*"
+tree-sitter-asciidoc_inline = "*"
+```
+
+Python:
+
+```sh
+pip install tree-sitter-asciidoc
+```
+
+C, Go, and Swift bindings are generated as well; see each grammar's `bindings/`
+directory.
+
+## Editor integration
+
+Any tree-sitter host can load the grammar. For an editor that supports language
+injection (for example Neovim via `nvim-treesitter`), register **both** grammars
+and the injection query so inline markup is highlighted inside blocks. The
+queries under `queries/` (`highlights.scm`, `injections.scm`) are the starting
+point.
+
+## Development
+
+Prerequisites: [pnpm](https://pnpm.io/) and the
+[tree-sitter CLI](https://github.com/tree-sitter/tree-sitter) (pinned in
+`package.json`, currently `0.25.10`). Use the pinned CLI; a different version
+reshuffles the generated tables and the committed `src/tree_sitter/array.h`.
+
+```sh
+pnpm install          # install dev dependencies
+pnpm generate         # regenerate both parsers from grammar.js
+pnpm test             # run the corpus tests for both grammars
+```
+
+To work on a single grammar, `cd` into `tree-sitter-asciidoc` or
+`tree-sitter-asciidoc_inline` and run `tree-sitter generate` / `tree-sitter
+test` there. Corpus tests live in each grammar's `test/corpus/`.
+
+CI regenerates the parsers and fails if the committed output drifts, so run
+`pnpm generate` and commit the regenerated `src/` before pushing. Formatting is
+enforced by pre-commit (Biome for JavaScript, clang-format for the C scanner).
+
+A few things worth knowing before you hack on the grammar:
+
+- Most block- and span-level boundaries are decided by a hand-written **external
+  scanner** in C (`src/scanner.c`), not by the grammar rules alone.
+- `tree-sitter test --update` rewrites expected trees, but it strips the `|||`
+  delimiter suffix that some corpus files use to embed literal `====` / `---` in
+  test input. Update those files by hand.
+- The queries are loaded by `tree-sitter test`, so a stale node name in a `.scm`
+  file fails the whole run.
+
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) and
+[docs/DESIGN_DECISIONS.md](docs/DESIGN_DECISIONS.md) before making structural
+changes.
+
+## Documentation
+
+- [Architecture](docs/ARCHITECTURE.md): how the block and inline grammars and their scanners work
+- [Design decisions](docs/DESIGN_DECISIONS.md): the choices behind the current shape, and why
+- [Limitations](docs/LIMITATIONS.md): what is not handled (yet) and how it currently parses
+- [Roadmap](docs/ROADMAP.md): what we want to improve next
+
+## License
+
+Apache-2.0. See [LICENSE](LICENSE).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,122 @@
+# Architecture
+
+This document explains how `tree-sitter-asciidoc` is put together, so you can
+find your way around before changing it.
+
+## The two-grammar split
+
+AsciiDoc, like Markdown, has a clean separation between **block** structure
+(what blocks a document is made of) and **inline** structure (the markup inside
+a line of text). tree-sitter handles this best with two grammars:
+
+- `tree-sitter-asciidoc` (scope `source.asciidoc`) parses block structure.
+- `tree-sitter-asciidoc_inline` (scope `source.asciidoc_inline`) parses span-level
+  markup.
+
+The block grammar never tries to understand `*bold*` or `link:...[]`. It parses
+a document into blocks and treats the text of each block as opaque `line`s. The
+inline grammar is then run on that text through tree-sitter's **injection**
+mechanism.
+
+Why split at all? Inline AsciiDoc is context-sensitive (constrained vs
+unconstrained formatting, attribute references, macros) and the block level has
+its own context sensitivity (delimited block nesting, list/section levels). One
+combined grammar plus one combined external scanner would be far harder to
+reason about and to keep unambiguous. Two smaller grammars, each with a focused
+scanner, are easier to maintain and to test.
+
+```
+document (block grammar)
+|- section
+|   |- title1
+|   `- section_block
+|       `- paragraph
+|           `- line   <-- injected: parsed by the inline grammar
+|- listing_block
+|   `- listing_block_body
+`- table_block
+    `- table_cell
+        `- table_cell_content   <-- injected
+```
+
+## Injection
+
+`tree-sitter-asciidoc/queries/injections.scm` tells the host to parse certain
+block-grammar nodes with the inline grammar:
+
+- `paragraph` and `line` content become `asciidoc_inline`
+- `table_cell` content becomes `asciidoc_inline`
+- a block macro `target` becomes `asciidoc_inline`
+- source/diagram code blocks inject the detected language (see below)
+
+Source-language injection is a nice payoff of parsing block attribute lists into
+structure. For `[source,ruby]`, the language is a real node (the second
+positional attribute), and for a diagram like `[mermaid]` it is the block style
+itself. The injection query reads those nodes directly instead of running a
+regex over an opaque attribute string.
+
+## External scanners
+
+Most of the interesting decisions happen in a hand-written external scanner in C
+(`src/scanner.c` in each grammar), not in the `grammar.js` rules. tree-sitter's
+generated LR parser cannot, on its own, decide things like "is this `----` the
+start or the end of a listing block" or "is this `*` a bullet or emphasis." The
+scanner provides those tokens (declared in each grammar's `externals`).
+
+### Block scanner
+
+The block scanner keeps a serialized **stack of open blocks**
+(`Scanner.buffer`, an array of `{kind, counter}`), where `kind` is the block
+type (delimited, listing, literal, sidebar, quoted, fenced, table, ...) and
+`counter` is the delimiter length. When it sees a delimiter line it compares
+against the stack top to decide start vs end, and pushes or pops accordingly.
+The stack is serialized and deserialized so incremental re-parsing works.
+
+It also emits, at the start of a line:
+
+- section title markers (`title_h0_marker`..`title_h5_marker`), where the level
+  is the run length of `=` (or `#` for Markdown ATX headings)
+- list markers (`*`, `-`, `.`, ordered digit/alpha/roman, callouts)
+- the indented-literal marker, document-attribute markers, table markers,
+  description-list terms, and comment markers
+
+`scanner_is_matching_raw_block()` reports whether we are inside a raw block
+(listing/literal/fenced), where most markup is suppressed.
+
+### Inline scanner
+
+The inline scanner's main job is **constrained formatting**. AsciiDoc
+distinguishes `*bold*` (constrained: needs word boundaries) from `**bold**`
+(unconstrained). The scanner emits an opening delimiter token (for example
+`_emphasis_begin`) only when a valid matching close exists later on the line, so
+a stray `*` or the `#` in "issue #2" stays punctuation instead of starting a
+formatting node that never closes. The same approach drives the two-character
+openers for typographic quotes (`"` + `` ` `` and `'` + `` ` ``) and the hard
+line break.
+
+## Grammar structure highlights
+
+A few rules are worth knowing because they shape large parts of the tree:
+
+- **Sections** nest by heading level. A level-1 section (`==`) contains its
+  content plus any deeper section, and each level closes when a same-or-higher
+  heading appears. The heading nodes stay `title1`..`title5`, wrapped in a
+  `section`. Container blocks (open/sidebar/quote/delimited/table cells) keep a
+  flat `section_block` instead.
+- **`section_block`** is the generic content-block wrapper (an optional
+  attribute list / block title, followed by one block). Keeping it as the
+  content wrapper is what let section nesting be added without rewriting the
+  highlight and injection queries.
+- **Attribute lists** (`[...]`) are parsed into `positional_attr` (carrying
+  `block_style` plus `#id` / `.role` / `%option` shorthand on the first entry)
+  and `named_attr` (`attribute_name` = `attribute_value`). The inline grammar
+  parses macro attribute lists the same way.
+
+## Build and test flow
+
+`grammar.js` is the source of truth. `tree-sitter generate` compiles it to
+`src/parser.c` (plus `grammar.json`, `node-types.json`), which are committed.
+The external scanner `src/scanner.c` is hand-written and compiled alongside.
+Corpus tests in `test/corpus/*.txt` assert the parse tree for sample input;
+`tree-sitter test` runs them and also loads the queries, so a broken query
+fails the test run.

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -1,0 +1,114 @@
+# Design decisions
+
+This records the non-obvious choices behind the current grammar, so they are not
+re-litigated or accidentally undone. For how the pieces fit together, see
+[ARCHITECTURE.md](ARCHITECTURE.md).
+
+## Split block and inline grammars
+
+AsciiDoc is parsed by a block grammar that injects an inline grammar (see
+[ARCHITECTURE.md](ARCHITECTURE.md)). The alternative, one grammar that handles
+both, would need a single external scanner juggling block nesting and
+constrained inline formatting at once. The split keeps each grammar and its
+scanner small enough to reason about, mirrors how tree-sitter's Markdown grammar
+is built, and lets the inline grammar be reused wherever inline content appears
+(paragraphs, table cells, macro targets).
+
+## Boundaries live in the external scanner
+
+AsciiDoc has too much context sensitivity for a pure LR grammar: a delimiter
+line can open or close a block depending on what is already open, `*` is a
+bullet at the start of a line and emphasis mid-line, and constrained formatting
+depends on word boundaries and on a matching delimiter existing later in the
+line. These decisions are made in C in `src/scanner.c` and surfaced as external
+tokens. The grammar rules then stay declarative.
+
+Consequence: the scanner carries serialized state (the open-block stack), so it
+behaves correctly under incremental re-parsing.
+
+## Constrained formatting via lookahead-gated openers
+
+The inline scanner emits an opening delimiter (for example `_emphasis_begin`)
+only when a valid matching close exists later on the same line. This is the
+mechanism that keeps a lone `*`, the `#` in "issue #2", or the `_` in
+`do_something_useful` as plain punctuation rather than error-recovering into an
+unterminated formatting node. Typographic-quote openers and the hard line break
+use the same gate.
+
+## Sections wrap content but keep `title1`..`title5`
+
+When section nesting was added, two shapes were possible: rename headings to a
+single `title` node, or keep the existing `title1`..`title5` and wrap them in a
+new `section`. We kept the level-specific heading nodes and wrapped them. The
+heading level is already encoded in the marker token, so a generic `title` would
+not add information, and renaming would break every existing highlight query and
+any downstream consumer. The additive choice landed cleanly with no query
+changes.
+
+Sections nest at the document level only. Inside container blocks
+(open/sidebar/quote/delimited blocks, table cells) a heading stays a flat
+`section_block`, because headings there are rare (usually discrete headings) and
+nesting them would widen the blast radius for little gain.
+
+An illegal level skip (for example `==` straight to `====`) still nests rather
+than erroring: a section body accepts any deeper section, and the innermost open
+section greedily claims a deeper heading.
+
+## `section_block` is the content wrapper, and it stayed
+
+`section_block` wraps a single content block (an optional attribute list / block
+title plus one block). Keeping it as the wrapper, and routing only headings
+through the new `section` nodes, is what allowed section nesting to be a purely
+additive change: the existing highlight and injection queries match
+`section_block` and kept working unchanged.
+
+## Attribute lists are parsed into structure
+
+Both block attribute lists (`[source#id.role%opt,ruby,cols="1,2"]`) and inline
+macro attribute lists (`image:x[Alt Text,200,role=external]`) are parsed into
+`positional_attr` and `named_attr` nodes, with the first positional carrying the
+style and the `#id` / `.role` / `%option` shorthand. Earlier these were a single
+opaque string.
+
+Rules that fall out of matching Asciidoctor:
+
+- A quoted value may contain commas (`["Arthur, King"]`); an unquoted value may
+  not (the comma separates entries).
+- An unquoted **named** value may contain `=` (a URL query string, say); a
+  positional value may not, because the `=` is what makes an entry named.
+- `stem` / `latexmath` / `pass` keep their attribute raw and unsplit, since math
+  and passthrough content must not be comma-split.
+
+The block and inline grammars use the same node names for these so consumers
+learn one shape.
+
+## Markdown compatibility, where Asciidoctor allows it
+
+Asciidoctor accepts some Markdown syntax. We support what it does:
+
+- ATX headings (`#`..`######`) map to the same section levels as `=`.
+- Fenced code blocks (` ``` `) map onto the listing block, tracked with a
+  dedicated stack kind so a backtick fence never closes a `----` listing of the
+  same length. The opening fence's info string (the language) is pulled into the
+  start marker.
+- Markdown blockquotes (`>`) are supported.
+
+## Text replacements use source forms
+
+Inline replacements match what you type, not the rendered entity: `->`, `=>`,
+`<-`, `<=`, `(C)`, `(R)`, `(TM)`, `...`. (An earlier version matched the HTML
+entities like `-&gt;`, which never appear in source.)
+
+## Counter attribute references
+
+`{counter:name}` and the silent `{counter2:name}` (with an optional
+`{counter:name:5}` seed) parse to a dedicated `counter` node. The function name
+and its trailing colon are one token, so a plain `{counter}` reference still
+resolves to an ordinary attribute reference by longest match.
+
+## Generated parser is committed; use the pinned CLI
+
+`src/parser.c` and friends are generated from `grammar.js` and committed, and CI
+fails if they drift. Always regenerate with the tree-sitter CLI version pinned
+in `package.json`. A different CLI version rewrites `src/tree_sitter/array.h` and
+reshuffles tables, producing a noisy, version-specific diff.

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -1,0 +1,77 @@
+# Limitations
+
+Known gaps and rough edges, with how each currently parses. These are not bugs
+in the "wrong output for valid input" sense so much as places where the grammar
+is coarser than full AsciiDoc semantics. Improvements are tracked in
+[ROADMAP.md](ROADMAP.md).
+
+## Lists do not nest
+
+Nested list markers (`**`, `***`, `..`) produce flat sibling items, not a nested
+list tree. The marker depth is captured (the marker text is `**` etc.), but a
+deeper item is a sibling of the shallower one rather than a child.
+
+```
+* a
+** b      parsed as two sibling items, not b nested under a
+* c
+```
+
+This is the single biggest structural gap. A correct fix needs the scanner to
+track a stack of marker depths; see [ROADMAP.md](ROADMAP.md).
+
+## Hanging-indent continuations under admonitions
+
+A hanging-indented continuation line under an admonition (or a paragraph) is
+parsed as an indented literal block, so it is highlighted as raw/monospace text:
+
+```
+NOTE: Line 1
+  Line 2      parsed as a separate indented literal block
+```
+
+This is upstream issue #41. The root cause is that the external scanner emits
+the indented-literal marker for any whitespace-led line without knowing whether
+that line starts a new block or continues the previous one, and blank lines (the
+real block separator) are invisible to the grammar. A clean fix needs reliable
+blank-line / line-ending tokenization; see [ROADMAP.md](ROADMAP.md).
+
+## Plain paragraphs are line-by-line
+
+Consecutive non-blank lines at the document level are parsed as separate
+single-line paragraphs rather than one multi-line paragraph. This rarely matters
+for highlighting, but consumers should not assume a paragraph node spans every
+line of a visual paragraph.
+
+## Sections nest only at the document level
+
+Inside container blocks (open, sidebar, quote, delimited blocks, table cells) a
+heading is a flat `section_block`, not a nested `section`. Headings in those
+positions are unusual (typically discrete headings), so this is a deliberate
+scope choice rather than an oversight.
+
+## Inline macro gating is not enforced
+
+`kbd:`, `btn:`, and `menu:` are always parsed. In AsciiDoc they require the
+`:experimental:` document attribute. A static grammar cannot easily track
+document attributes, so these are accepted unconditionally. This is
+over-permissive, not incorrect for documents that do enable the attribute.
+
+## Conditional preprocessor directives are not scoped
+
+`ifdef::`, `ifndef::`, `ifeval::`, and `endif::` parse as generic block (or
+inline) macros. The content between an opening directive and its `endif` is not
+grouped or conditionally included; that is a preprocessing concern outside a
+syntax tree.
+
+## A few inline replacements are missing
+
+The em dash (`--` between words) and the in-word smart apostrophe (the `'` in
+`Olaf's`) are not converted. The explicit typographic apostrophe form
+(`` `' ``) is handled. Arrows, `(C)`/`(R)`/`(TM)`, and ellipsis are handled.
+
+## Malformed input
+
+An unterminated quoted attribute value (for example `[cols="1,2]` with no
+closing quote) is malformed and parses to an error node. tree-sitter recovers on
+the next edit; this only bites while such input is being typed.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,63 @@
+# Roadmap
+
+What we would like to improve, roughly in priority order. Each entry links back
+to the limitation it addresses in [LIMITATIONS.md](LIMITATIONS.md). This is a
+wish list and a record of analysis, not a commitment or a schedule.
+
+## Reliable line-ending / blank-line tokenization
+
+This is the keystone change that unblocks the next two items. Today blank lines
+are consumed as `_NEWLINE` extras and are invisible to the grammar, and the
+external scanner cannot reliably tell "start of a block" from "middle of a
+block" because plain content lines never go through it (and tree-sitter discards
+scanner-state mutations on a `false` return).
+
+Routing every line ending through the scanner (so it always knows whether the
+next line begins a new block) would give a dependable `at_block_start` signal.
+It is an invasive change to a core mechanism, so it deserves its own focused
+pass with heavy corpus testing.
+
+## List nesting
+
+Addresses [flat lists](LIMITATIONS.md#lists-do-not-nest). The plan is the
+scanner-stack approach: track a stack of marker depths (a signature per nesting
+level), emit nest/dedent tokens (like indentation-based INDENT/DEDENT), serialize
+the stack, and wrap nested lists in the grammar. This is the deepest scanner
+change of the set and shares the line-tracking machinery above. It handles mixed
+marker styles and multi-level dedents the way Asciidoctor does.
+
+## Hanging-indent continuations
+
+Addresses upstream issue #41
+([hanging indents](LIMITATIONS.md#hanging-indent-continuations-under-admonitions)).
+Once block-start state is reliable (first item above), the indented-literal
+marker can be gated so a continuation line under an admonition / paragraph / list
+item stays text instead of becoming a literal block, while a genuine indented
+literal block after a blank line still parses correctly.
+
+## Smaller, self-contained improvements
+
+These do not depend on the line-tracking work:
+
+- **Em dash and in-word smart apostrophe**
+  ([replacements](LIMITATIONS.md#a-few-inline-replacements-are-missing)). The em
+  dash is contextual (between word characters) and must not collide with the
+  open-block `--` marker, so it needs care.
+- **Grammar scope metadata.** Both `tree-sitter.json` files declare
+  `"scope": "source.j2"` (a copy-paste leftover). They should be
+  `source.asciidoc` and `source.asciidoc_inline`, and the duplicate
+  `file-types` entries cleaned up.
+- **Discrete headings and block options.** Now that block attribute lists are
+  parsed into structure, `[discrete]`, `[%collapsible]`, and similar could be
+  recognized semantically rather than left as generic style/option nodes.
+
+## Possible future work
+
+- Inter-document xref targets (`xref:doc.adoc#id[]`) as structured nodes.
+- Richer table column-spec parsing (`cols="1,2a"`) from the already-structured
+  attribute list.
+- A `CONTRIBUTING.md` and per-grammar query docs once the above settle.
+
+If you want to pick something up, the limitations doc explains the current
+behavior for each item, and the architecture and design-decision docs explain
+the machinery you will be working against.


### PR DESCRIPTION
The README was a single line, so this fills it out to match what you'd expect from a mature tree-sitter grammar, and adds a `docs/` directory for the things that don't belong in a README.

README now covers: what the grammar parses, the two-grammar (block + injected inline) split, installation per binding, and the development workflow (pnpm, the pinned tree-sitter CLI, the `|||` corpus-delimiter gotcha, queries loaded by the test run).

New under `docs/`:
- **ARCHITECTURE.md** - the block/inline split, language injection, and what each external scanner does (open-block stack, constrained-formatting openers).
- **DESIGN_DECISIONS.md** - the non-obvious choices and their rationale (why the grammar is split, why boundaries live in the scanner, why sections keep `title1`..`title5`, how attribute lists are parsed, Markdown compat, etc.).
- **LIMITATIONS.md** - known gaps and how each currently parses (list nesting, hanging indents / #41, experimental-macro gating, ...).
- **ROADMAP.md** - what we'd like to improve next, with the line-ending tokenization work called out as the keystone that unblocks list nesting and the hanging-indent fix.

Docs only, no grammar changes.