### PR TITLE
docs: clean up the crates.io badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # tree-sitter-asciidoc
 
-![Crates.io Version](https://img.shields.io/crates/v/tree-sitter-asciidoc?label=tree-sitter-asciidoc(crates.io))
-![Crates.io Version](https://img.shields.io/crates/v/tree-sitter-asciidoc_inline?label=tree-sitter-asciidoc_inline(crates.io))
+[![tree-sitter-asciidoc on crates.io](https://img.shields.io/crates/v/tree-sitter-asciidoc?label=tree-sitter-asciidoc)](https://crates.io/crates/tree-sitter-asciidoc)
+[![tree-sitter-asciidoc-inline on crates.io](https://img.shields.io/crates/v/tree-sitter-asciidoc-inline?label=tree-sitter-asciidoc-inline)](https://crates.io/crates/tree-sitter-asciidoc-inline)
 
 A [tree-sitter](https://tree-sitter.github.io/tree-sitter/) grammar for
 [AsciiDoc](https://docs.asciidoctor.org/asciidoc/latest/), the markup language.


### PR DESCRIPTION
Tidies the two version badges:

- make them clickable (link to the crate on crates.io)
- drop the redundant, parenthesis-laden `label=...(crates.io)` in favor of a clean label
- give the two badges distinct alt text (both were `Crates.io Version`)
- use the canonical hyphenated crate name `tree-sitter-asciidoc-inline` for the inline badge (crates.io normalizes `_`/`-`, so the old underscore form resolved too, but the hyphen is the real name)

Note: if the badges currently render "invalid", that's a shields.io / crates.io upstream hiccup (a `serde` badge shows the same right now), not something the README can fix.